### PR TITLE
Updates to TCA 1.3.0 and new async APIs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/pointfreeco/swift-composable-architecture",
-            .upToNextMajor(from: "0.27.1"))
+            .upToNextMajor(from: "1.3.0"))
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "composable-core-bluetooth",
     platforms: [
-        .iOS(.v13),
+        .iOS(.v15),
         .macOS(.v10_15),
         .tvOS(.v13),
         .watchOS(.v8),

--- a/Sources/ComposableCoreBluetooth/ATTRequest.swift
+++ b/Sources/ComposableCoreBluetooth/ATTRequest.swift
@@ -9,7 +9,7 @@
 import Foundation
 import CoreBluetooth
 
-public struct ATTRequest: Equatable {
+public struct ATTRequest: Equatable, Sendable {
     
     let rawValue: CBATTRequest?
     public let characteristic: Characteristic

--- a/Sources/ComposableCoreBluetooth/Central.swift
+++ b/Sources/ComposableCoreBluetooth/Central.swift
@@ -9,7 +9,7 @@
 import Foundation
 import CoreBluetooth
 
-public struct Central: Equatable {
+public struct Central: Equatable, Sendable {
     
     let rawValue: CBCentral?
     public let identifier: UUID

--- a/Sources/ComposableCoreBluetooth/Manager+Live.swift
+++ b/Sources/ComposableCoreBluetooth/Manager+Live.swift
@@ -27,9 +27,9 @@ private struct BluetoothManagerSendableBox: Sendable {
 }
 
 extension BluetoothManager {
-        
     public static func live(queue: DispatchQueue?, options: InitializationOptions?) -> BluetoothManager {
         let task = Task<BluetoothManagerSendableBox, Never>(operation: { @MainActor in
+            // TODO: Remove autounwrap
             var continuation: AsyncStream<Action>.Continuation!
             let stream = AsyncStream<Action> { continuation = $0 }
             

--- a/Sources/ComposableCoreBluetooth/PeripheralManager+Live.swift
+++ b/Sources/ComposableCoreBluetooth/PeripheralManager+Live.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2020 Philipp Gabriel. All rights reserved.
 //
 
+#if !os(watchOS)
+
 import Foundation
 import CoreBluetooth
 import ComposableArchitecture
@@ -27,8 +29,6 @@ private struct PeripheralManagerSendableBox: Sendable {
     var delegateStreamContinuation: AsyncStream<PeripheralManager.Action>.Continuation
 }
 
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
 extension PeripheralManager {
     
     public static func live(queue: DispatchQueue?, options: InitializationOptions?) -> PeripheralManager {
@@ -175,3 +175,5 @@ extension PeripheralManager {
         }
     }
 }
+
+#endif

--- a/Sources/ComposableCoreBluetooth/PeripheralManager+Mock.swift
+++ b/Sources/ComposableCoreBluetooth/PeripheralManager+Mock.swift
@@ -14,111 +14,52 @@ import ComposableArchitecture
 @available(watchOS, unavailable)
 extension PeripheralManager {
     
-    public static func mock(
-        create: @escaping (AnyHashable, DispatchQueue?, InitializationOptions?) -> Effect<Action> = { _, _, _ in
-            _unimplemented("create")
-        },
-        destroy: @escaping (AnyHashable) -> Effect<Never> = { _ in
-            _unimplemented("destroy")
-        },
-        addService: @escaping (AnyHashable, MutableService) -> Effect<Never> = { _, _ in
-            _unimplemented("addService")
-        },
-        removeService: @escaping (AnyHashable, MutableService) -> Effect<Never> = { _, _ in
-            _unimplemented("removeService")
-        },
-        removeAllServices: @escaping (AnyHashable) -> Effect<Never> = { _ in
-            _unimplemented("removeAllServices")
-        },
-        startAdvertising: @escaping (AnyHashable, AdvertisementData?) -> Effect<Never> = { _, _ in
-            _unimplemented("startAdvertising")
-        },
-        stopAdvertising: @escaping (AnyHashable) -> Effect<Never> = { _ in
-            _unimplemented("stopAdvertising")
-        },
-        updateValue: @escaping (AnyHashable, Data, MutableCharacteristic, [Central]?) -> Effect<Bool> = { _, _, _, _ in
-            _unimplemented("updateValue")
-        },
-        respondToRequest: @escaping (AnyHashable, ATTRequest, CBATTError.Code) -> Effect<Never> = { _, _, _ in
+    public static let mock = Self(
+        delegate: { unimplemented() },
+        addService: { _ in unimplemented() },
+        removeService: { _ in unimplemented() },
+        removeAllServices: { unimplemented() },
+        startAdvertising: { _ in unimplemented() },
+        stopAdvertising: { unimplemented() },
+        updateValue: { _, _, _ in unimplemented() },
+        respondToRequest: { _, _ in
             _unimplemented("respondToRequest")
         },
-        setDesiredConnectionLatency: @escaping (AnyHashable, CBPeripheralManagerConnectionLatency, Central) -> Effect<Never> = { _, _, _ in
+        setDesiredConnectionLatency: { _, _ in
             _unimplemented("setDesiredConnectionLatency")
         },
-        publishL2CAPChannel: @escaping (AnyHashable, Bool) -> Effect<Never> = { _, _ in
+        publishL2CAPChannel: { _ in
             _unimplemented("publishL2CAPChannel")
         },
-        unpublishL2CAPChannel: @escaping (AnyHashable, CBL2CAPPSM) -> Effect<Never> = { _, _ in
+        unpublishL2CAPChannel: { _ in
             _unimplemented("unpublishL2CAPChannel")
-        }
-    ) -> Self {
-        Self(
-            create: create,
-            destroy: destroy,
-            addService: addService,
-            removeService: removeService,
-            removeAllServices: removeAllServices,
-            startAdvertising: startAdvertising,
-            stopAdvertising: stopAdvertising,
-            updateValue: updateValue,
-            respondToRequest: respondToRequest,
-            setDesiredConnectionLatency: setDesiredConnectionLatency,
-            publishL2CAPChannel: publishL2CAPChannel,
-            unpublishL2CAPChannel: unpublishL2CAPChannel
-        )
-    }
+        },
+        state: { unimplemented() },
+        _authorization: { unimplemented() }
+    )
+
     
-    public static func failing(
-        create: @escaping (AnyHashable, DispatchQueue?, InitializationOptions?) -> Effect<Action> = { _, _, _ in
-            _unimplemented("create")
-        },
-        destroy: @escaping (AnyHashable) -> Effect<Never> = { _ in
-            _unimplemented("destroy")
-        },
-        addService: @escaping (AnyHashable, MutableService) -> Effect<Never> = { _, _ in
-            _unimplemented("addService")
-        },
-        removeService: @escaping (AnyHashable, MutableService) -> Effect<Never> = { _, _ in
-            _unimplemented("removeService")
-        },
-        removeAllServices: @escaping (AnyHashable) -> Effect<Never> = { _ in
-            _unimplemented("removeAllServices")
-        },
-        startAdvertising: @escaping (AnyHashable, AdvertisementData?) -> Effect<Never> = { _, _ in
-            _unimplemented("startAdvertising")
-        },
-        stopAdvertising: @escaping (AnyHashable) -> Effect<Never> = { _ in
-            _unimplemented("stopAdvertising")
-        },
-        updateValue: @escaping (AnyHashable, Data, MutableCharacteristic, [Central]?) -> Effect<Bool> = { _, _, _, _ in
-            _unimplemented("updateValue")
-        },
-        respondToRequest: @escaping (AnyHashable, ATTRequest, CBATTError.Code) -> Effect<Never> = { _, _, _ in
+    public static let failing = Self(
+        delegate: { unimplemented() },
+        addService: { _ in unimplemented() },
+        removeService: { _ in unimplemented() },
+        removeAllServices: { unimplemented() },
+        startAdvertising: { _ in unimplemented() },
+        stopAdvertising: { unimplemented() },
+        updateValue: { _, _, _ in unimplemented() },
+        respondToRequest: { _, _ in
             _unimplemented("respondToRequest")
         },
-        setDesiredConnectionLatency: @escaping (AnyHashable, CBPeripheralManagerConnectionLatency, Central) -> Effect<Never> = { _, _, _ in
+        setDesiredConnectionLatency: { _, _ in
             _unimplemented("setDesiredConnectionLatency")
         },
-        publishL2CAPChannel: @escaping (AnyHashable, Bool) -> Effect<Never> = { _, _ in
+        publishL2CAPChannel: { _ in
             _unimplemented("publishL2CAPChannel")
         },
-        unpublishL2CAPChannel: @escaping (AnyHashable, CBL2CAPPSM) -> Effect<Never> = { _, _ in
+        unpublishL2CAPChannel: { _ in
             _unimplemented("unpublishL2CAPChannel")
-        }
-    ) -> Self {
-        Self(
-            create: create,
-            destroy: destroy,
-            addService: addService,
-            removeService: removeService,
-            removeAllServices: removeAllServices,
-            startAdvertising: startAdvertising,
-            stopAdvertising: stopAdvertising,
-            updateValue: updateValue,
-            respondToRequest: respondToRequest,
-            setDesiredConnectionLatency: setDesiredConnectionLatency,
-            publishL2CAPChannel: publishL2CAPChannel,
-            unpublishL2CAPChannel: unpublishL2CAPChannel
-        )
-    }
+        },
+        state: { unimplemented() },
+        _authorization: { unimplemented() }
+    )
 }

--- a/Sources/ComposableCoreBluetooth/PeripheralManager+Mock.swift
+++ b/Sources/ComposableCoreBluetooth/PeripheralManager+Mock.swift
@@ -70,40 +70,40 @@ extension PeripheralManager {
     
     public static func failing(
         create: @escaping (AnyHashable, DispatchQueue?, InitializationOptions?) -> Effect<Action> = { _, _, _ in
-            .unimplemented("create")
+            _unimplemented("create")
         },
         destroy: @escaping (AnyHashable) -> Effect<Never> = { _ in
-            .unimplemented("destroy")
+            _unimplemented("destroy")
         },
         addService: @escaping (AnyHashable, MutableService) -> Effect<Never> = { _, _ in
-            .unimplemented("addService")
+            _unimplemented("addService")
         },
         removeService: @escaping (AnyHashable, MutableService) -> Effect<Never> = { _, _ in
-            .unimplemented("removeService")
+            _unimplemented("removeService")
         },
         removeAllServices: @escaping (AnyHashable) -> Effect<Never> = { _ in
-            .unimplemented("removeAllServices")
+            _unimplemented("removeAllServices")
         },
         startAdvertising: @escaping (AnyHashable, AdvertisementData?) -> Effect<Never> = { _, _ in
-            .unimplemented("startAdvertising")
+            _unimplemented("startAdvertising")
         },
         stopAdvertising: @escaping (AnyHashable) -> Effect<Never> = { _ in
-            .unimplemented("stopAdvertising")
+            _unimplemented("stopAdvertising")
         },
         updateValue: @escaping (AnyHashable, Data, MutableCharacteristic, [Central]?) -> Effect<Bool> = { _, _, _, _ in
-            .unimplemented("updateValue")
+            _unimplemented("updateValue")
         },
         respondToRequest: @escaping (AnyHashable, ATTRequest, CBATTError.Code) -> Effect<Never> = { _, _, _ in
-            .unimplemented("respondToRequest")
+            _unimplemented("respondToRequest")
         },
         setDesiredConnectionLatency: @escaping (AnyHashable, CBPeripheralManagerConnectionLatency, Central) -> Effect<Never> = { _, _, _ in
-            .unimplemented("setDesiredConnectionLatency")
+            _unimplemented("setDesiredConnectionLatency")
         },
         publishL2CAPChannel: @escaping (AnyHashable, Bool) -> Effect<Never> = { _, _ in
-            .unimplemented("publishL2CAPChannel")
+            _unimplemented("publishL2CAPChannel")
         },
         unpublishL2CAPChannel: @escaping (AnyHashable, CBL2CAPPSM) -> Effect<Never> = { _, _ in
-            .unimplemented("unpublishL2CAPChannel")
+            _unimplemented("unpublishL2CAPChannel")
         }
     ) -> Self {
         Self(

--- a/Sources/ComposableCoreBluetooth/PeripheralManager.swift
+++ b/Sources/ComposableCoreBluetooth/PeripheralManager.swift
@@ -12,115 +12,77 @@ import ComposableArchitecture
 
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-public struct PeripheralManager {
+public struct PeripheralManager: Sendable {
     
-    var create: (AnyHashable, DispatchQueue?, InitializationOptions?) -> Effect<Action> = { _, _, _ in
-        _unimplemented("create")
-    }
+    public var delegate: @Sendable () async -> AsyncStream<Action>
     
-    var destroy: (AnyHashable) -> Effect<Never> = { _ in
-        _unimplemented("destroy")
-    }
+    public var addService: @Sendable (MutableService) async -> Void
     
-    var addService: (AnyHashable, MutableService) -> Effect<Never> = { _, _ in
-        _unimplemented("addService")
-    }
+    public var removeService: @Sendable (MutableService) async -> Void
     
-    var removeService: (AnyHashable, MutableService) -> Effect<Never> = { _, _ in
-        _unimplemented("removeService")
-    }
+    public var removeAllServices: @Sendable () async -> Void
+        
+    public var startAdvertising: @Sendable (AdvertisementData?) async -> Void
     
-    var removeAllServices: (AnyHashable) -> Effect<Never> = { _ in
-        _unimplemented("removeAllServices")
-    }
+    public var stopAdvertising: @Sendable () async -> Void
+
+    public var updateValue: @Sendable (Data, MutableCharacteristic, [Central]?) async -> Bool
     
-    var startAdvertising: (AnyHashable, AdvertisementData?) -> Effect<Never> = { _, _ in
-        _unimplemented("startAdvertising")
-    }
+    public var respondToRequest: @Sendable (ATTRequest, CBATTError.Code) async -> Void
+
+    public var setDesiredConnectionLatency: @Sendable (CBPeripheralManagerConnectionLatency, Central) async -> Void
+
+    public var publishL2CAPChannel: @Sendable (Bool) async -> Void
+
+    public var unpublishL2CAPChannel: @Sendable (CBL2CAPPSM) async -> Void
+
+    public var state: @Sendable () async -> CBManagerState
     
-    var stopAdvertising: (AnyHashable) -> Effect<Never> = { _ in
-        _unimplemented("stopAdvertising")
-    }
-    
-    var updateValue: (AnyHashable, Data, MutableCharacteristic, [Central]?) -> Effect<Bool> = { _, _, _, _ in
-        _unimplemented("updateValue")
-    }
-    
-    var respondToRequest: (AnyHashable, ATTRequest, CBATTError.Code) -> Effect<Never> = { _, _, _ in
-        _unimplemented("respondToRequest")
-    }
-    
-    var setDesiredConnectionLatency: (AnyHashable, CBPeripheralManagerConnectionLatency, Central) -> Effect<Never> = { _, _, _ in
-        _unimplemented("setDesiredConnectionLatency")
-    }
-    
-    var publishL2CAPChannel: (AnyHashable, Bool) -> Effect<Never> = { _, _ in
-        _unimplemented("publishL2CAPChannel")
-    }
-    
-    var unpublishL2CAPChannel: (AnyHashable, CBL2CAPPSM) -> Effect<Never> = { _, _ in
-        _unimplemented("unpublishL2CAPChannel")
-    }
-    
-    var state: (AnyHashable) -> CBManagerState = { _ in
-        _unimplemented("state")
-    }
-    
-    var _authorization: () -> CBManagerAuthorization = {
-        _unimplemented("authorization")
-    }
+    public var _authorization: @Sendable () -> CBManagerAuthorization
 }
 
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 extension PeripheralManager {
     
-    public func create(id: AnyHashable, queue: DispatchQueue?, options: InitializationOptions?) -> Effect<Action> {
-        create(id, queue, options)
+    public func add(service: MutableService) async {
+        await addService(service)
     }
     
-    public func destroy(id: AnyHashable) -> Effect<Never> {
-        destroy(id)
+    public func remove(service: MutableService) async {
+        await removeService(service)
     }
     
-    public func add(id: AnyHashable, service: MutableService) -> Effect<Never> {
-        addService(id, service)
+    public func removeAllServices() async {
+        await removeAllServices()
     }
     
-    public func remove(id: AnyHashable, service: MutableService) -> Effect<Never> {
-        removeService(id, service)
+    public func startAdvertising(_ advertisementData: AdvertisementData?) async {
+        await startAdvertising(advertisementData)
     }
     
-    public func removeAllServices(id: AnyHashable) -> Effect<Never> {
-        removeAllServices(id)
+    public func stopAdvertising() async {
+        await stopAdvertising()
     }
     
-    public func startAdvertising(id: AnyHashable, _ adverstimentData: AdvertisementData?) -> Effect<Never> {
-        startAdvertising(id, adverstimentData)
+    public func updateValue(_ data: Data, for characteristic: MutableCharacteristic, onSubscribed centrals: [Central]?) async -> Bool {
+        await updateValue(data, characteristic, centrals)
     }
     
-    public func stopAdvertising(id: AnyHashable) -> Effect<Never> {
-        stopAdvertising(id)
+    public func respond(to request: ATTRequest, with result: CBATTError.Code) async {
+        await respondToRequest(request, result)
     }
     
-    public func updateValue(id: AnyHashable, _ data: Data, for characteristic: MutableCharacteristic, onSubscribed centrals: [Central]?) -> Effect<Bool> {
-        updateValue(id, data, characteristic, centrals)
+    public func setDesiredConnectionLatency(_ latency: CBPeripheralManagerConnectionLatency, for central: Central) async {
+        await setDesiredConnectionLatency(latency, central)
     }
     
-    public func respond(id: AnyHashable, to request: ATTRequest, with result: CBATTError.Code) -> Effect<Never> {
-        respondToRequest(id, request, result)
+    public func publishL2CAPChannel(withEncryption: Bool) async {
+        await publishL2CAPChannel(withEncryption)
     }
     
-    public func setDesiredConnectionLatency(id: AnyHashable, _ latency: CBPeripheralManagerConnectionLatency, for central: Central) -> Effect<Never> {
-        setDesiredConnectionLatency(id, latency, central)
-    }
-    
-    public func publishL2CAPChannel(id: AnyHashable, withEncryption: Bool) -> Effect<Never> {
-        publishL2CAPChannel(id, withEncryption)
-    }
-    
-    public func unpublishL2CAPChannel(id: AnyHashable, _ psm: CBL2CAPPSM) -> Effect<Never> {
-        unpublishL2CAPChannel(id, psm)
+    public func unpublishL2CAPChannel(_ psm: CBL2CAPPSM) async {
+        await unpublishL2CAPChannel(psm)
     }
     
     @available(iOS 13.1, macOS 10.15, macCatalyst 13.1, tvOS 13.0, watchOS 6.0, *)
@@ -132,8 +94,7 @@ extension PeripheralManager {
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 extension PeripheralManager {
-    
-    public enum Action: Equatable {
+    public enum Action: Equatable, Sendable {
         case willRestore(RestorationOptions)
         case didAddService(Result<Service, BluetoothError>)
         case didSubscribeTo(Characteristic, Central)
@@ -179,7 +140,7 @@ extension PeripheralManager {
         }
     }
     
-    public struct RestorationOptions: Equatable {
+    public struct RestorationOptions: Equatable, Sendable {
         
         public let services: [Service]?
         public let advertisementData: AdvertisementData?
@@ -190,7 +151,7 @@ extension PeripheralManager {
         }
     }
     
-    public struct AdvertisementData: Equatable {
+    public struct AdvertisementData: Equatable, Sendable {
         
         public let localName: String?
         public let manufacturerData: Data?

--- a/Sources/ComposableCoreBluetooth/PeripheralManager.swift
+++ b/Sources/ComposableCoreBluetooth/PeripheralManager.swift
@@ -155,10 +155,10 @@ extension PeripheralManager {
         
         public let localName: String?
         public let manufacturerData: Data?
-        public let serviceData: [CBUUID: Data]?
-        public let serviceUUIDs: [CBUUID]?
-        public let overflowServiceUUIDs: [CBUUID]?
-        public let solicitedServiceUUIDs: [CBUUID]?
+        @UncheckedSendable public var serviceData: [CBUUID: Data]?
+        @UncheckedSendable public var serviceUUIDs: [CBUUID]?
+        @UncheckedSendable public var overflowServiceUUIDs: [CBUUID]?
+        @UncheckedSendable public var solicitedServiceUUIDs: [CBUUID]?
         public let txPowerLevel: NSNumber?
         public let isConnectable: Bool?
         


### PR DESCRIPTION
- [x] TCA 1.3.0 compatibility
- [x] `PeripheralManager` now uses same async APIs as `BluetoothManager`
- [x] Prevents `PeripheralManager` from building _at all_ on watchOS 